### PR TITLE
Add Xcode11 xcresult support

### DIFF
--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -1,11 +1,13 @@
 require 'fastlane_core'
 require 'pty'
 require 'open3'
+require 'tmpdir'
 require 'fileutils'
 require 'terminal-table'
 require 'xcov-core'
 require 'pathname'
 require 'json'
+require 'xcresult'
 
 module Xcov
   class Manager
@@ -38,17 +40,26 @@ module Xcov
     def parse_xccoverage
       # Find .xccoverage file
       # If no xccov direct path, use the old derived data path method
-      if xccov_file_direct_path.nil?
+      if xccov_file_direct_paths.nil?
         extension = Xcov.config[:legacy_support] ? "xccoverage" : "xccovreport"
         test_logs_path = derived_data_path + "Logs/Test/"
         xccoverage_files = Dir["#{test_logs_path}*.#{extension}", "#{test_logs_path}*.xcresult/*/action.#{extension}"].sort_by { |filename| File.mtime(filename) }.reverse
+
+        if xccoverage_files.empty?
+          xcresult_paths = Dir["#{test_logs_path}*.xcresult"].sort_by { |filename| File.mtime(filename) }.reverse
+          xcresult_paths.each do |xcresult_path|
+            parser = XCResult::Parser.new(path: xcresult_path)
+            xccoverage_files += parser.export_xccovreports(destination: Dir.mktmpdir)
+          end
+        end
 
         unless test_logs_path.directory? && !xccoverage_files.empty?
           ErrorHandler.handle_error("XccoverageFileNotFound")
         end
       else
-        xccoverage_files = ["#{xccov_file_direct_path}"]
+        xccoverage_files = xccov_file_direct_paths
       end
+
 
       # Convert .xccoverage file to json
       ide_foundation_path = Xcov.config[:legacy_support] ? nil : Xcov.config[:ideFoundationPath]
@@ -155,12 +166,19 @@ module Xcov
       return product_builds_path.parent.parent
     end
 
-    def xccov_file_direct_path
+    def xccov_file_direct_paths
       # If xccov_file_direct_path was supplied, return
       if Xcov.config[:xccov_file_direct_path].nil?
           return nil
       end
-      return Pathname.new(Xcov.config[:xccov_file_direct_path])
+
+      path = Xcov.config[:xccov_file_direct_path]
+      if File.extname(path) == '.xcresult'
+        parser = XCResult::Parser.new(path: path)
+        return parser.export_xccovreports(destination: Dir.mktmpdir)
+      end
+
+      return [Pathname.new(path).to_s]
     end
 
   end

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -77,12 +77,12 @@ module Xcov
           key: :xccov_file_direct_path,
           short_option: "-f",
           env_name: "XCOV_FILE_DIRECT_PATH",
-          description: "The path to the xccoverage/xccovreport file to parse to generate code coverage",
+          description: "The path to the xccoverage/xccovreport/xcresult file to parse to generate code coverage",
           optional: true,
           verify_block: proc do |value|
             v = File.expand_path(value.to_s)
-            raise "xccoverage/xccovreport file does not exist".red unless File.exist?(v)
-            raise "Invalid xccov file type (must be xccoverage or xccovreport)".red unless value.end_with? "xccoverage" or value.end_with? "xccovreport"
+            raise "xccoverage/xccovreport/xcresult file does not exist".red unless File.exist?(v)
+            raise "Invalid xccov file type (must be xccoverage, xccovreport, xcresult)".red unless value.end_with? "xccoverage" or value.end_with? "xccovreport" or value.end_with? "xcresult"
           end
         ),
         FastlaneCore::ConfigItem.new(

--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'xcodeproj'
   spec.add_dependency 'terminal-table'
   spec.add_dependency 'multipart-post'
+  spec.add_dependency 'xcresult', '~> 0.1.1'
 
   # Development only
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
## Motivation
See 👉  https://github.com/fastlane-community/danger-xcov/issues/26

## Description
- Updated `:xccov_file_direct_path` to accept `.xcresult` extension
- Uses new https://github.com/fastlane-community/xcresult gem to parse `.xcresult` file and export the `.xccovreport` files to a destination directory when:
  - `:xccov_file_direct_path` is given and ends in `.xcresult`
  - no `.xccoverage` or `.xccovreport` files are found 

## To test
Update your `Gemfile` to 👇 and run `bundle install` or `bundle update xcov`
```
gem 'xcov`, :git => 'https://github.com/fastlane-community/xcov.git', :branch => 'joshdholtz-xcresult-support'
```