### PR TITLE
Export .xccovarchive and .xccovreport

### DIFF
--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -38,6 +38,8 @@ module Xcov
     end
 
     def parse_xccoverage
+      xccoverage_files = []
+
       # xcresults to parse and export after collecting
       xcresults_to_parse_and_export = []
 
@@ -59,10 +61,14 @@ module Xcov
           ErrorHandler.handle_error("XccoverageFileNotFound")
         end
       else
-        if File.extname(path) == '.xcresult'
-          xcresults_to_parse_and_export += xccov_file_direct_paths
-        else
-          xccoverage_files = xccov_file_direct_paths
+        # Iterate over direct paths and find .xcresult files
+        # that need to be processed before getting coverage
+        xccov_file_direct_paths.each do |path|
+          if File.extname(path) == '.xcresult'
+            xcresults_to_parse_and_export << path
+          else
+            xccoverage_files << path
+          end
         end
       end
 
@@ -215,7 +221,7 @@ module Xcov
 
           report_paths
         rescue
-          UI.error("Error occured while exporting xccovreport from xcresult '#{path}'")
+          UI.error("Error occured while exporting xccovreport from xcresult '#{xcresult_path}'")
           UI.error("Make sure you have both Xcode 11 selected and pointing to the correct xcresult file")
           UI.crash!("Failed to export xccovreport from xcresult'")
         end

--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -38,6 +38,9 @@ module Xcov
     end
 
     def parse_xccoverage
+      # xcresults to parse and export after collecting
+      xcresults_to_parse_and_export = []
+
       # Find .xccoverage file
       # If no xccov direct path, use the old derived data path method
       if xccov_file_direct_paths.nil?
@@ -48,17 +51,53 @@ module Xcov
         if xccoverage_files.empty?
           xcresult_paths = Dir["#{test_logs_path}*.xcresult"].sort_by { |filename| File.mtime(filename) }.reverse
           xcresult_paths.each do |xcresult_path|
-            xccoverage_files += export_paths_from_xcresult!(xcresult_path)
+            xcresults_to_parse_and_export << xcresult_path
           end
         end
 
-        unless test_logs_path.directory? && !xccoverage_files.empty?
+        unless test_logs_path.directory?
           ErrorHandler.handle_error("XccoverageFileNotFound")
         end
       else
-        xccoverage_files = xccov_file_direct_paths
+        if File.extname(path) == '.xcresult'
+          xcresults_to_parse_and_export += xccov_file_direct_paths
+        else
+          xccoverage_files = xccov_file_direct_paths
+        end
       end
 
+      # Iterates over xcresults
+      # Exports .xccovarchives
+      # Exports .xccovreports and collects the paths
+      xcresults_to_parse_and_export.each do |xcresult_path|
+        begin
+          parser = XCResult::Parser.new(path: xcresult_path)
+          destination = File.dirname(xcresult_path)
+
+          # Exporting to same directory as xcresult
+          archive_paths = parser.export_xccovarchives(destination: destination)
+          report_paths = parser.export_xccovreports(destination: destination)
+
+          # Informating user of export paths
+          archive_paths.each do |path|
+            UI.important("Copying .xccovarchive to #{path}") 
+          end
+          report_paths.each do |path|
+            UI.important("Copying .xccovreport to #{path}") 
+          end
+
+          xccoverage_files += report_paths
+        rescue
+          UI.error("Error occured while exporting xccovreport from xcresult '#{path}'")
+          UI.error("Make sure you have both Xcode 11 selected and pointing to the correct xcresult file")
+          UI.crash!("Failed to export xccovreport from xcresult'")
+        end
+      end
+
+      # Errors if no coverage files were found
+      if xccoverage_files.empty?
+        ErrorHandler.handle_error("XccoverageFileNotFound")
+      end
 
       # Convert .xccoverage file to json
       ide_foundation_path = Xcov.config[:legacy_support] ? nil : Xcov.config[:ideFoundationPath]
@@ -172,16 +211,15 @@ module Xcov
       end
 
       path = Xcov.config[:xccov_file_direct_path]
-      if File.extname(path) == '.xcresult'
-        return export_paths_from_xcresult!(path)
-      end
-
       return [Pathname.new(path).to_s]
     end
 
     def export_paths_from_xcresult!(path)
       parser = XCResult::Parser.new(path: path)
-      return parser.export_xccovreports(destination: Dir.mktmpdir)
+      destination = File.dirname(path)
+
+      parser.export_xccovarchives(destination: destination)
+      return parser.export_xccovreports(destination: destination)
     rescue
       UI.error("Error occured while exporting xccovreport from xcresult '#{path}'")
       UI.error("Make sure you have both Xcode 11 selected and pointing to the correct xcresult file")

--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'xcodeproj'
   spec.add_dependency 'terminal-table'
   spec.add_dependency 'multipart-post'
-  spec.add_dependency 'xcresult', '~> 0.1.1'
+  spec.add_dependency 'xcresult', '~> 0.2.0'
 
   # Development only
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
## Motivation
Fixes #157

## Description
- Updates `xcresult` to `0.2.0` which introduces `export_xccovarchives`
- Now calls `export_xccovarchives` along with `export_xccovreports`
  - Exports both of these to output directory

### Output
```sh
[17:28:30]: $ xcodebuild -showBuildSettings -workspace ../../myproject/myproject-ios/Example/myproject.xcworkspace -scheme myproject-Example
2019-10-01 17:28:32.422 xcodebuild[56457:3813433]  DTDeviceKit: deviceType from 00008006-001573C02EE2002E was NULL
2019-10-01 17:28:32.528 xcodebuild[56457:3813289] [MT] DTDeviceKit: deviceType from 00008006-001573C02EE2002E was NULL
2019-10-01 17:28:32.535 xcodebuild[56457:3813289] [MT] DTDeviceKit: deviceType from 00008006-001573C02EE2002E was NULL
2019-10-01 17:28:32.561 xcodebuild[56457:3813289] [MT] DTDeviceKit: deviceType from 00008006-001573C02EE2002E was NULL
[17:56:07]: Copying .xccovarchive to /Users/josh/Desktop/xcovoutput/action_0.xccovarchive
[17:56:07]: Copying .xccovreport to /Users/josh/Desktop/xcovoutput/action_0.xccovreport
[17:28:32]: $ /Users/josh/Projects/fastlane/xcov/lib/xcov-core/bin/xcov-core -s /Users/josh/Library/Developer/Xcode/DerivedData/myproject-afhudsgvvlwnfvgjhcssklndegjm/Logs/Test/action_0.xccovreport -o ./fastlane/xcov_report/tmp/report.json20191001-56452-8ctgsx --ide-foundation-path /Applications/Xcode-11.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation
[17:28:32]: ▸ Loading...
[17:28:32]: ▸ Opening .xccoverage file at path: /Users/josh/Library/Developer/Xcode/DerivedData/myproject-afhudsgvvlwnfvgjhcssklndegjm/Logs/Test/action_0.xccovreport
[17:28:32]: ▸ Parsing .xccoverage file...
[17:28:32]: ▸ File successfully parsed
[17:28:32]: ▸ Serializing coverage report...
[17:28:32]: ▸ Report successfully serialized
[17:28:32]: ▸ Writing report on disk...
[17:28:32]: ▸ Coverage report successfully created at path: /Users/josh/Projects/fastlane/xcov/fastlane/xcov_report/tmp/report.json20191001-56452-8ctgsx
+----------------------------------+-------+
|           xcov Coverage Report           |
+----------------------------------+-------+
| myproject.framework              | 4.94% |
| Pods_myproject_Example.framework | 0.00% |
| Pods_myproject_Tests.framework   | 0.00% |
| Starscream.framework             | 0.00% |
| myproject_Example.app            | 0.94% |
+----------------------------------+-------+
```

## To test
Update your `Gemfile` to 👇 and run `bundle install` or `bundle update xcov`
```
gem 'xcov`, :git => 'https://github.com/fastlane-community/xcov.git', :branch => 'joshdholtz-export-xccovarchive-and-xccreport'
```