### PR TITLE
Add file path to json output

### DIFF
--- a/lib/xcov/model/source.rb
+++ b/lib/xcov/model/source.rb
@@ -56,6 +56,7 @@ module Xcov
     def json_value
       value = {
         "name" => @name,
+        "path" => @location,
         "coverage" => @coverage,
         "type" => @type,
         "functions" => @functions ? @functions.map{ |function| function.json_value } : []


### PR DESCRIPTION
## What 
Adds the file path when generating json reports (via `--json_report`).

#### Old output

```json
"files": [
  { 
    "name": "MyFile.swift",
    "coverage": 0,
    ...
```
#### New output

```json
"files": [
  { 
    "name": "MyFile.swift",
    "path":"/Users/me/project/MyFile.swift",
    "coverage": 0,
    ...
```

## Why

To assist automated tooling, it's helpful to know the path of the files. In larger projects, it's not uncommon to have duplicate file names across targets. Reconciling the coverage `name` with the actual file requires either a) parsing the Xcode coverage reports ourselves or b) keeping track of the corresponding target and parsing Xcode project files. Both options seem pretty unfortunate.

## Open questions

- Should this be gated behind a flag?
  - Opinion: Adding this field will increase the size of the generated json reports but I don't think the amount will be significant (esp after compression). Since this is an additive change, it is unlikely to break existing tooling. 
- Should this be added to any other reports?
  - Opinion: I'm assuming HTML reports are used mostly for humans and JSON reports are used mostly for tooling. If nobody is asking for it I don't see a reason to add it to the HTML reports. 
