### PR TITLE
Calculate total project cov according to line count for each target

### DIFF
--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -1,4 +1,3 @@
-
 module Xcov
   class Report < Xcov::Base
 
@@ -9,18 +8,20 @@ module Xcov
 
     def initialize(targets)
       @targets = targets
-      @coverage = average_coverage(targets)
+      @coverage = total_project_coverage(targets)
       @displayable_coverage = self.create_displayable_coverage
       @coverage_color = self.create_coverage_color
       @summary = self.create_summary
     end
 
-    def average_coverage targets
+    def total_project_coverage targets
       return 0 if targets.count == 0
+
       return targets.first.coverage if targets.count == 1
 
-      acc_coverage = targets.reduce(0) { |acc, target| acc + target.coverage }
-      acc_coverage.to_f / targets.count
+      acc_total_covered_lines = targets.reduce(0) { |acc, target| acc + target.total_covered_lines }
+      acc_total_executable_lines = targets.reduce(0) { |acc, target| acc + target.total_executable_lines }
+      acc_total_covered_lines.to_f / acc_total_executable_lines.to_f
     end
 
     def print_description

--- a/lib/xcov/model/target.rb
+++ b/lib/xcov/model/target.rb
@@ -6,13 +6,15 @@ module Xcov
     attr_accessor :name
     attr_accessor :files
     attr_accessor :file_templates
+    attr_accessor :total_covered_lines
+    attr_accessor :total_executable_lines
 
     def initialize(name, files)
       @name = CGI::escapeHTML(name)
       @files = files
-      totalCoveredLines = files.reduce(0) { |acc, file| acc + file.coveredLines }
-      totalExecutableLines = files.reduce(0) { |acc, file| acc + file.executableLines }
-      @coverage = files.count == 0 || totalExecutableLines == 0 ? 0.0 : totalCoveredLines.to_f / totalExecutableLines.to_f
+      @total_covered_lines = files.reduce(0) { |acc, file| acc + file.coveredLines }
+      @total_executable_lines = files.reduce(0) { |acc, file| acc + file.executableLines }
+      @coverage = files.count == 0 || @total_executable_lines == 0 ? 0.0 : @total_covered_lines.to_f / @total_executable_lines.to_f
       @displayable_coverage = self.create_displayable_coverage
       @coverage_color = self.create_coverage_color
       @id = Target.create_id(name)


### PR DESCRIPTION
This should address https://github.com/fastlane-community/xcov/issues/168 and provide a project summary coverage number that is more accurate. A simple mean of the target coverages does not properly account for target size.