### PR TITLE
Display average coverage in log

### DIFF
--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -158,6 +158,11 @@ module Xcov
       report.targets.each do |target|
         table_rows << [target.name, target.displayable_coverage]
       end
+
+      if report.targets.count > 0 
+        table_rows << ["Average", report.average_coverage(report.targets)]
+      end
+
       puts Terminal::Table.new({
         title: "xcov Coverage Report".green,
         rows: table_rows

--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -160,7 +160,7 @@ module Xcov
       end
 
       if report.targets.count > 0 
-        table_rows << ["Average", report.average_coverage(report.targets)]
+        table_rows << ["Average Coverage", "#{"%.2f%%" % (report.coverage*100)}"]
       end
 
       puts Terminal::Table.new({


### PR DESCRIPTION
Addresses this [issue](https://github.com/fastlane-community/xcov/issues/181).

It now adds the average coverage value of the report at the end of the coverage report to the console. 

### As-is
```
+---------------------+--------+
|     xcov Coverage Report     |
+---------------------+--------+
| A.framework               | 12.34% |
| B.framework               | 56.78% |
+---------------------+--------+
```

### To-be
```
+---------------------+--------+
|     xcov Coverage Report     |
+---------------------+--------+
| A.framework               | 12.34% |
| B.framework               | 56.78% |
| Average Coverage     | xx.yy%  |
+---------------------+--------+
```