### PR TITLE
Adding use_system_scm option

### DIFF
--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -101,6 +101,14 @@ module Xcov
           type: String,
           optional: true
         ),
+        FastlaneCore::ConfigItem.new(
+          key: :use_system_scm,
+          env_name: "XCOV_USE_SYSTEM_SCM",
+          description: "Lets xcodebuild use system's scm configuration",
+          optional: true,
+          is_string: false,
+          default_value: false
+        ),
 
         # Report options
         FastlaneCore::ConfigItem.new(


### PR DESCRIPTION
Adding `use_system_scm` option because `xcodebuild` was failing to resolve Swift Package dependencies on our CI.