### PR TITLE
Accept multiple xccov_file_direct_path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,9 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: macOS-11
+    steps:
+      - uses: actions/checkout@v2
+      - run: bundle install
+      - run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -47,7 +47,7 @@ module Xcov
 
       # Find .xccoverage file
       # If no xccov direct path, use the old derived data path method
-      if xccov_file_direct_paths.nil?
+      if xccov_file_direct_paths.empty?
         extension = Xcov.config[:legacy_support] ? "xccoverage" : "xccovreport"
         
         test_logs_path = derived_data_path + "Logs/Test/"
@@ -198,11 +198,11 @@ module Xcov
     def xccov_file_direct_paths
       # If xccov_file_direct_path was supplied, return
       if Xcov.config[:xccov_file_direct_path].nil?
-          return nil
+          return []
       end
 
-      path = Xcov.config[:xccov_file_direct_path]
-      return [Pathname.new(path).to_s]
+      paths = Xcov.config[:xccov_file_direct_path]
+      return paths.map { |path| Pathname.new(path).to_s }
     end
 
     def process_xcresults!(xcresult_paths)

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -77,12 +77,16 @@ module Xcov
           key: :xccov_file_direct_path,
           short_option: "-f",
           env_name: "XCOV_FILE_DIRECT_PATH",
-          description: "The path to the xccoverage/xccovreport/xcresult file to parse to generate code coverage",
+          description: "The path or array of paths to the xccoverage/xccovreport/xcresult files to parse to generate code coverage",
+          type: Array,
           optional: true,
           verify_block: proc do |value|
-            v = File.expand_path(value.to_s)
-            raise "xccoverage/xccovreport/xcresult file does not exist".red unless File.exist?(v)
-            raise "Invalid xccov file type (must be xccoverage, xccovreport, xcresult)".red unless value.end_with? "xccoverage" or value.end_with? "xccovreport" or value.end_with? "xcresult"
+            values = value.is_a?(String) ? [value] : value
+            values.each do |value|
+              v = File.expand_path(value.to_s)
+              raise "xccoverage/xccovreport/xcresult file does not exist".red unless File.exist?(v)
+              raise "Invalid xccov file type (must be xccoverage, xccovreport, xcresult)".red unless value.end_with? "xccoverage" or value.end_with? "xccovreport" or value.end_with? "xcresult"
+            end
           end
         ),
         FastlaneCore::ConfigItem.new(

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -1,0 +1,32 @@
+require "fileutils"
+require "fastlane_core"
+require "xcov/manager"
+
+describe Xcov::Manager do
+  subject(:manager) { described_class.new(config) }
+
+  before do
+    project = double()
+    allow(project).to receive(:select_scheme)
+    allow(FastlaneCore::Project).to receive(:new).and_return project
+    allow(FastlaneCore::Project).to receive(:detect_projects)
+  end
+
+  describe "#xccov_file_direct_paths" do
+    subject { manager.send(:xccov_file_direct_paths) }
+
+    context "when xccov_file_direct_path is nil" do
+      let(:config) { {} }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when xccov_file_direct_path is an array of strings" do
+      let(:config) { {xccov_file_direct_path: ["foo", "bar"]} }
+
+      it "returns given strings" do
+        expect(subject).to eq ["foo", "bar"]
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require "coveralls"
-Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
-
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
 end

--- a/spec/xcov_spec.rb
+++ b/spec/xcov_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "xcov command" do
+  subject(:xcov) { `#{File.expand_path("../bin/xcov", __dir__)} #{args} 2>/dev/null` }
+
+  describe "xccov_file_direct_path option" do
+    context "when a string is passed" do
+      let(:args) { "--xccov_file_direct_path foo" }
+
+      it "accepts a string" do
+        expect(subject).to include '["foo"]'
+      end
+    end
+
+    context "when a string is passed" do
+      let(:args) { "--xccov_file_direct_path foo,bar" }
+
+      it "accepts a comma-separated string and convert it to an array of strings" do
+        expect(subject).to include '["foo", "bar"]'
+      end
+    end
+  end
+end

--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Close #195 

- Define `xccov_file_direct_path` option to receive both a string and an array of strings.
    - To not break backward compatibility, I didn't change the option key (ideally it should be plural though).
- Set up rspec and CI using GitHub Actions.
- Add minimal specs to check if `xccov_file_direct_path` option works.