### PR TITLE
Support for include_zero_targets option

### DIFF
--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -58,6 +58,10 @@ module Xcov
       # Create target objects
       targets = targets.map { |target| Target.map(target) }.sort { |lhs, rhs| lhs.name <=> rhs.name }
 
+      if !Xcov.config[:include_zero_targets]
+         targets = targets.select { |target| target.coverage > 0 }
+      end
+
       Report.new(targets)
     end
 

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -190,6 +190,13 @@ module Xcov
           default_value: false
         ),
         FastlaneCore::ConfigItem.new(
+          key: :include_zero_targets,
+          env_name: "XCOV_INCLUDE_ZERO_TARGETS",
+          description: "Final report will include target even if the coverage is 0%",
+          is_string: false,
+          default_value: true
+        ),
+        FastlaneCore::ConfigItem.new(
           key: :exclude_targets,
           optional: true,
           conflicting_options: [:include_targets, :only_project_targets],


### PR DESCRIPTION
removes targets with 0% coverage from final report