### PR TITLE
Add `env_name` definitions to `ConfigItem`'s that were missing them

### DIFF
--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -176,18 +176,21 @@ module Xcov
         ),
         FastlaneCore::ConfigItem.new(
           key: :skip_slack,
+          env_name: "XCOV_SKIP_SLACK",
           description: "Don't publish to slack, even when an URL is given",
           is_string: false,
           default_value: false
         ),
         FastlaneCore::ConfigItem.new(
           key: :slack_username,
+          env_name: "XCOV_SLACK_USERNAME",
           description: "The username which is used to publish to slack",
           default_value: "xcov",
           optional: true
         ),
         FastlaneCore::ConfigItem.new(
           key: :slack_message,
+          env_name: "XCOV_SLACK_MESSAGE",
           description: "The message which is published together with a successful report",
           default_value: "Your *xcov* coverage report",
           optional: true
@@ -218,18 +221,21 @@ module Xcov
         ),
         FastlaneCore::ConfigItem.new(
           key: :exclude_targets,
+          env_name: "XCOV_EXCLUDE_TARGETS",
           optional: true,
           conflicting_options: [:include_targets, :only_project_targets],
           description: "Comma separated list of targets to exclude from coverage report"
         ),
         FastlaneCore::ConfigItem.new(
           key: :include_targets,
+          env_name: "XCOV_INCLUDE_TARGETS",
           optional: true,
           conflicting_options: [:exclude_targets, :only_project_targets],
           description: "Comma separated list of targets to include in coverage report. If specified then exlude_targets will be ignored"
         ),
         FastlaneCore::ConfigItem.new(
           key: :only_project_targets,
+          env_name: "XCOV_ONLY_PROJECT_TARGETS",
           optional: true,
           conflicting_options: [:exclude_targets, :include_targets],
           description: "Display the coverage only for main project targets (e.g. skip Pods targets)",


### PR DESCRIPTION
# Motivation

We leverage the `xcov` action in our Fastfile and it's great (thanks for the hard work so far 💪). 

One thing we are trying to do however is keep our main Fastfile as lean as possible to make it easy for people to parse what is going on. 

The problem that we face however its that sometimes, we are required to pass the same arguments to an action in multiple places, but the duplication in the Fastfile becomes a bit noisy. 

Instead, we have a pattern where we set sensible global defaults in a hidden lane via the environment variable. What we'd like is to take this:

```ruby
run_tests(coverage: true)
xcov(
  xccov_file_direct_path: Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH],
  include_targets: XCOV_TARGETS.join(','),
  scheme: UNIT_TESTS_SCHEME,
  slack_channel: '#notifications-global-ios',
  slack_message: '',
  slack_username: 'Coverage Reporter',
  json_report: true,
  output_directory: File.join(OUTPUT_DIR, 'coverage'),
)
```

And instead have this:

```ruby
run_tests(coverage: true)
xcov
```

While most of this is possible today, there are a couple of config items that don't currently have a `env_name` defined.

# Changes

In this PR, I go through all of the options and I add the `env_name` definition if it was missing. I follow a relatively simple naming pattern of `XCOV_{KEY_TO_UPPER_CASE}`.